### PR TITLE
Diary chat item 도메인 추가

### DIFF
--- a/src/main/java/com/example/demo/NyangtodacApplication.java
+++ b/src/main/java/com/example/demo/NyangtodacApplication.java
@@ -2,7 +2,9 @@ package com.example.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class NyangtodacApplication {
 

--- a/src/main/java/com/example/demo/domain/BaseEntity.java
+++ b/src/main/java/com/example/demo/domain/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.example.demo.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/demo/domain/chat/Chat.java
+++ b/src/main/java/com/example/demo/domain/chat/Chat.java
@@ -1,0 +1,47 @@
+package com.example.demo.domain.chat;
+
+import com.example.demo.domain.BaseEntity;
+import com.example.demo.domain.User;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "chat")
+public class Chat extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(columnDefinition = "TEXT")
+    private String response;
+
+    @Column
+    private Integer dangerScore;
+
+    protected Chat() {
+    }
+
+    private Chat(User user, String content) {
+        this.user = user;
+        this.content = content;
+    }
+
+    public static Chat of(User user, String content) {
+        return new Chat(user, content);
+    }
+
+    public void updateResponse(String response) {
+        this.response = response;
+    }
+
+    public void updateDangerScore(int dangerScore) {
+        this.dangerScore = dangerScore;
+    }
+}

--- a/src/main/java/com/example/demo/domain/diary/Diary.java
+++ b/src/main/java/com/example/demo/domain/diary/Diary.java
@@ -1,0 +1,45 @@
+package com.example.demo.domain.diary;
+
+import com.example.demo.domain.BaseEntity;
+import com.example.demo.domain.User;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "diary")
+public class Diary extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User author;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(20)")
+    private EmotionEnum emotion;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @OneToOne(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+    private DiaryFeedback feedback;
+
+    protected Diary() {
+    }
+
+    private Diary(User author, EmotionEnum emotion, String content) {
+        this.author = author;
+        this.emotion = emotion;
+        this.content = content;
+    }
+
+    public static Diary of(User author, EmotionEnum emotion, String content) {
+        return new Diary(author, emotion, content);
+    }
+
+    public void addFeedback(String feedbackContent) {
+        this.feedback = DiaryFeedback.of(this, feedbackContent);
+    }
+}

--- a/src/main/java/com/example/demo/domain/diary/DiaryFeedback.java
+++ b/src/main/java/com/example/demo/domain/diary/DiaryFeedback.java
@@ -1,0 +1,32 @@
+package com.example.demo.domain.diary;
+
+import com.example.demo.domain.BaseEntity;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "diary_feedback")
+public class DiaryFeedback extends BaseEntity {
+
+    @Id
+    private Long id;
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String feedback; //content?
+
+    protected DiaryFeedback() {
+    }
+
+    private DiaryFeedback(Diary diary, String feedback) {
+        this.diary = diary;
+        this.feedback = feedback;
+    }
+
+    public static DiaryFeedback of(Diary diary, String feedback) {
+        return new DiaryFeedback(diary, feedback);
+    }
+}

--- a/src/main/java/com/example/demo/domain/diary/EmotionEnum.java
+++ b/src/main/java/com/example/demo/domain/diary/EmotionEnum.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.diary;
+
+public enum EmotionEnum {
+    EXCELLENT,
+    GOOD,
+    SOSO,
+    BAD,
+    TERRIBLE,
+}

--- a/src/main/java/com/example/demo/domain/item/Item.java
+++ b/src/main/java/com/example/demo/domain/item/Item.java
@@ -1,0 +1,47 @@
+package com.example.demo.domain.item;
+
+import com.example.demo.domain.BaseEntity;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "item")
+public class Item extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Integer price;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(20)")
+    private ItemCategoryEnum category;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    protected Item() {
+    }
+
+    private Item(Integer price, ItemCategoryEnum category, String imageUrl) {
+        this.price = price;
+        this.category = category;
+        this.imageUrl = imageUrl;
+    }
+
+    public static Item of(Integer price, ItemCategoryEnum category, String imageUrl) {
+        return new Item(price, category, imageUrl);
+    }
+
+    public static Item of(String imageUrl) {
+        return new Item(null, null, imageUrl);
+    }
+
+    public void updateDetail(Integer price, ItemCategoryEnum category) {
+        this.price = price;
+        this.category = category;
+    }
+
+
+}

--- a/src/main/java/com/example/demo/domain/item/ItemCategoryEnum.java
+++ b/src/main/java/com/example/demo/domain/item/ItemCategoryEnum.java
@@ -1,0 +1,5 @@
+package com.example.demo.domain.item;
+
+public enum ItemCategoryEnum {
+    // 모자, 옷, 신발
+}

--- a/src/main/java/com/example/demo/domain/item/UserItem.java
+++ b/src/main/java/com/example/demo/domain/item/UserItem.java
@@ -1,0 +1,42 @@
+package com.example.demo.domain.item;
+
+import com.example.demo.domain.BaseEntity;
+import com.example.demo.domain.User;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "user_item")
+public class UserItem extends BaseEntity {
+
+    @EmbeddedId
+    private UserItemId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("userId")
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("itemId")
+    @JoinColumn(name = "item_id")
+    private Item item;
+
+    @Column(nullable = false)
+    private Boolean isUsed = false;
+
+    protected UserItem() {
+    }
+
+    private UserItem(User user, Item item) {
+        this.user = user;
+        this.item = item;
+    }
+
+    public void useItem() {
+        this.isUsed = true;
+    }
+
+    public void cancelUse() {
+        this.isUsed = false;
+    }
+}

--- a/src/main/java/com/example/demo/domain/item/UserItemId.java
+++ b/src/main/java/com/example/demo/domain/item/UserItemId.java
@@ -1,0 +1,34 @@
+package com.example.demo.domain.item;
+
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class UserItemId implements Serializable {
+    private Long userId;
+    private Long itemId;
+
+    protected UserItemId() {
+    }
+
+    public UserItemId(Long userId, Long itemId) {
+        this.userId = userId;
+        this.itemId = itemId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserItemId that = (UserItemId) o;
+        return Objects.equals(userId, that.userId) &&
+                Objects.equals(itemId, that.itemId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, itemId);
+    }
+}


### PR DESCRIPTION
### Diary
- 일기를 중심으로 피드백(AI코멘트)가 처리되도록 연관관계 편의 메서드 도입
- User와의 관계는 author 속성으로 단방향으로 정의, 서비스 레이어에서 findByAuthor로 처리하는것을 고려했음

### Chat
- response와 dangerScore는 외부 API 호출 이후 추가 될 수 있도록 nullable로 설정

### item
- 이미지 url은 필수, 아이템 카테고리, 가격은 나중에 설정 할 수 있도록 설계
- ItemCategoryEnum 정의, 명세 필요
- UserItem 테이블 복합키 UserItemId `@EmbeddedId` 사용 구현