### PR TITLE
미션 관련 도메인 설계

### DIFF
--- a/src/main/java/com/example/demo/domain/category/CategoryDetail.java
+++ b/src/main/java/com/example/demo/domain/category/CategoryDetail.java
@@ -1,0 +1,31 @@
+package com.example.demo.domain.category;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "categoryDetails")
+public class CategoryDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "detailCategoryId")
+    private Long id;
+
+    @Column(nullable = false)
+    private String detailCategoryName;
+
+    @OneToMany(mappedBy = "categoryDetail")
+    private List<MissionCategoryDetail> missionCategoryDetails = new ArrayList<>();
+
+    protected CategoryDetail() {
+    }
+
+}

--- a/src/main/java/com/example/demo/domain/category/MissionCategoryDetail.java
+++ b/src/main/java/com/example/demo/domain/category/MissionCategoryDetail.java
@@ -1,0 +1,32 @@
+package com.example.demo.domain.category;
+
+import com.example.demo.domain.mission.Mission;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "missionCategoryDeatils")
+public class MissionCategoryDetail {
+
+    @EmbeddedId
+    private MissionCategoryDetailId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("missionId")
+    @JoinColumn(name = "missionId")
+    private Mission mission;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("detailCategoryId")
+    @JoinColumn(name = "detailCategoryId")
+    private CategoryDetail categoryDetail;
+
+    protected MissionCategoryDetail() {
+    }
+
+}

--- a/src/main/java/com/example/demo/domain/category/MissionCategoryDetailId.java
+++ b/src/main/java/com/example/demo/domain/category/MissionCategoryDetailId.java
@@ -1,0 +1,40 @@
+package com.example.demo.domain.category;
+
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class MissionCategoryDetailId implements Serializable {
+
+    private Long missionId;
+    private Long detailCategoryId;
+
+    protected MissionCategoryDetailId() {
+    }
+
+    public MissionCategoryDetailId(Long missionId, Long detailCategoryId) {
+        this.missionId = missionId;
+        this.detailCategoryId = detailCategoryId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MissionCategoryDetailId that = (MissionCategoryDetailId) o;
+
+        return Objects.equals(missionId, that.missionId) && Objects.equals(detailCategoryId,
+            that.detailCategoryId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(missionId, detailCategoryId);
+    }
+
+}

--- a/src/main/java/com/example/demo/domain/common/Category.java
+++ b/src/main/java/com/example/demo/domain/common/Category.java
@@ -1,0 +1,7 @@
+package com.example.demo.domain.common;
+
+public enum Category {
+    REFRESH,        // 리프레시
+    EMPLOYMENT,     // 취업
+    DAILY           // 일상
+}

--- a/src/main/java/com/example/demo/domain/common/CustomMissionState.java
+++ b/src/main/java/com/example/demo/domain/common/CustomMissionState.java
@@ -1,0 +1,7 @@
+package com.example.demo.domain.common;
+
+public enum CustomMissionState {
+    WAITING,    // 필터 대기 상태
+    FILTERED,   // 승인 대기 상태(필터링은 되었지만 승인이 안된 경우)
+    REJECTED    // 승인 거절 상태
+}

--- a/src/main/java/com/example/demo/domain/mission/CustomMission.java
+++ b/src/main/java/com/example/demo/domain/mission/CustomMission.java
@@ -1,0 +1,66 @@
+package com.example.demo.domain.mission;
+
+import com.example.demo.domain.User;
+import com.example.demo.domain.common.Category;
+import com.example.demo.domain.common.CustomMissionState;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "customMissions")
+public class CustomMission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "customMissionId")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author", nullable = false)
+    private User author;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @Column
+    private Integer sentimentScore;
+
+    @Column
+    private Integer energyScore;
+
+    @Column
+    private Integer cognitiveScore;
+
+    @Column
+    private Integer relationshipScore;
+
+    @Column
+    private Integer stressScore;
+
+    @Column
+    private Integer employmentScore;
+
+    @Column
+    private Integer level;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CustomMissionState state;
+
+    protected CustomMission() {
+    }
+
+}

--- a/src/main/java/com/example/demo/domain/mission/Mission.java
+++ b/src/main/java/com/example/demo/domain/mission/Mission.java
@@ -1,0 +1,66 @@
+package com.example.demo.domain.mission;
+
+import com.example.demo.domain.category.MissionCategoryDetail;
+import com.example.demo.domain.common.Category;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "missions")
+public class Mission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "missionId")
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @Column(nullable = false)
+    private Integer sentimentScore;
+
+    @Column(nullable = false)
+    private Integer energyScore;
+
+    @Column(nullable = false)
+    private Integer cognitiveScore;
+
+    @Column(nullable = false)
+    private Integer relationshipScore;
+
+    @Column(nullable = false)
+    private Integer stressScore;
+
+    @Column(nullable = false)
+    private Integer employmentScore;
+
+    @Column(nullable = false)
+    private Integer selectionRate;
+
+    @Column(nullable = false)
+    private Integer completionRate;
+
+    @Column(nullable = false)
+    private Integer level;
+
+    @OneToMany(mappedBy = "mission")
+    private List<MissionCategoryDetail> missionCategoryDetails = new ArrayList<>();
+
+    protected Mission() {
+    }
+
+}

--- a/src/main/java/com/example/demo/domain/mission/UserMission.java
+++ b/src/main/java/com/example/demo/domain/mission/UserMission.java
@@ -1,0 +1,51 @@
+package com.example.demo.domain.mission;
+
+import com.example.demo.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "userMissions")
+public class UserMission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "userMissionId")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "missionId")
+    private Mission mission;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customMissionId")
+    private CustomMission customMission;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private Boolean done = false;
+
+    protected UserMission() {
+    }
+
+    @PrePersist
+    public void createdAt() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}


### PR DESCRIPTION
## 반영 사항

- **공통 Enum 추가**: 카테고리 3가지에 대한 Enum, 커스텀 미션 상태 3가지에 대한 Enum 생성
- **카테고리 도메인 모델링**: 미션에 여러 세부 태그를 붙일 수 있도록 다대다 관계 구현
- **미션 도메인 모델링**: ERD 기반 모델링
- **패키지 구조**: 'mission', 'category', 'common'  패키지로 분리