### PR TITLE
JWT 사용자 식별자를 email에서 id로 변경

### DIFF
--- a/src/main/java/com/example/demo/config/auth/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/example/demo/config/auth/CurrentUserArgumentResolver.java
@@ -34,11 +34,11 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
         if (authentication == null) {
             return null;
         }
+        
+        Long userId = Long.parseLong(authentication.getName());
 
-        String userEmail = authentication.getName();
-
-        return userRepository.findByEmail(userEmail)
+        return userRepository.findById(userId)
             .orElseThrow(
-                () -> new IllegalArgumentException("User not found with email: " + userEmail));
+                () -> new IllegalArgumentException("User not found with id: " + userId));
     }
 }

--- a/src/main/java/com/example/demo/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/demo/config/jwt/JwtTokenProvider.java
@@ -29,20 +29,20 @@ public class JwtTokenProvider {
         this.refreshTokenValidityInMilliseconds = refreshTokenValidity * 1000;
     }
 
-    public String createAccessToken(String userEmail) {
-        return createToken(userEmail, accessTokenValidityInMilliseconds);
+    public String createAccessToken(Long userId) {
+        return createToken(userId, accessTokenValidityInMilliseconds);
     }
 
-    public String createRefreshToken(String userEmail) {
-        return createToken(userEmail, refreshTokenValidityInMilliseconds);
+    public String createRefreshToken(Long userId) {
+        return createToken(userId, refreshTokenValidityInMilliseconds);
     }
 
-    private String createToken(String userEmail, long validityInMilliseconds) {
+    private String createToken(Long userId, long validityInMilliseconds) {
         Date now = new Date();
         Date validity = new Date(now.getTime() + validityInMilliseconds);
 
         return Jwts.builder()
-            .setSubject(userEmail)
+            .setSubject(String.valueOf(userId))
             .setIssuedAt(now)
             .setExpiration(validity)
             .signWith(key, SignatureAlgorithm.HS256)
@@ -70,8 +70,9 @@ public class JwtTokenProvider {
             userDetails.getAuthorities());
     }
 
-    public String getEmailFromToken(String token) {
-        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody()
-            .getSubject();
+    public Long getUserIdFromToken(String token) {
+        return Long.parseLong(
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody()
+                .getSubject());
     }
 }


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
기존에는 JWT에 사용자를 식별하기 위한 값으로 email을 사용한 것을 데이터베이스 조회 효율성과 시스템의 일관성을 높이기 위해 User 테이블의 Primary Key인 id로 사용자 식별자 변경.
1. JwtTokenProvider.java: JWT 토큰 생성 시, subject 필드에 email 대신 userId를 저장하도록 수정.
2. OAuth2SucccessHandler.java: 소셜 로그인 성공 후, 조회된 사용자의 id를 JwtTokenProvider에 전달하여 토큰을 생성하도록 변경.
3. CurrentUserArgumentResolver.java: CurrentUser 어노테이션으로 현재 로그인한 사용자 정보 조회 시, SecurityContext에 저장된 userId를 사용하여 userRepository.findById() 로 조회하도록 수정

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항


### 테스트 결과
- 로컬 및 개발 환경에서 소셜 로그인 시 정상적으로 JWT 토큰 발급 확인.
- 발급된 토큰을 사용하여 CurrentUser 어노테이션을 사용하는 테스트 API에 요청 시, 올바른 사용자 정보가 조회되는 것 확인.