### PR TITLE
고양이 생성, 조회, 수정(이름변경) API #38

### DIFF
--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                 session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**",
-                    "/oauth2/**")
+                    "/oauth2/**", "/h2-console/**")
                 .permitAll()
                 .requestMatchers("/api/v1/**").hasRole("USER")
                 .anyRequest().authenticated()

--- a/src/main/java/com/example/demo/controller/CatController.java
+++ b/src/main/java/com/example/demo/controller/CatController.java
@@ -1,0 +1,45 @@
+package com.example.demo.controller;
+
+import com.example.demo.config.auth.CurrentUser;
+import com.example.demo.domain.user.User;
+import com.example.demo.dto.cat.CatNameRequest;
+import com.example.demo.dto.cat.CatResponse;
+import com.example.demo.service.CatService;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cats")
+public class CatController {
+
+    private final CatService catService;
+
+    @PostMapping
+    public ResponseEntity<Void> createCat(@RequestBody CatNameRequest request,
+        @CurrentUser User user) {
+        CatResponse created = catService.create(user, request.getName());
+        String location = "/api/cats";
+        return ResponseEntity.created(URI.create(location)).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<CatResponse> getCat(@CurrentUser User user) {
+        CatResponse found = catService.get(user);
+        return ResponseEntity.ok(found);
+    }
+
+    @PutMapping
+    public ResponseEntity<CatResponse> renameCat(@RequestBody CatNameRequest request,
+        @CurrentUser User user) {
+        CatResponse updated = catService.rename(user, request.getName());
+        return ResponseEntity.ok(updated);
+    }
+}

--- a/src/main/java/com/example/demo/domain/cat/Cat.java
+++ b/src/main/java/com/example/demo/domain/cat/Cat.java
@@ -112,4 +112,8 @@ public class Cat {
     public List<OwnedItem> getEquippedItem() {
         return equippedItem.values().stream().toList();
     }
+
+    public void rename(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/example/demo/dto/cat/CatNameRequest.java
+++ b/src/main/java/com/example/demo/dto/cat/CatNameRequest.java
@@ -1,0 +1,9 @@
+package com.example.demo.dto.cat;
+
+import lombok.Getter;
+
+@Getter
+public class CatNameRequest {
+
+    private String name;
+}

--- a/src/main/java/com/example/demo/dto/cat/CatResponse.java
+++ b/src/main/java/com/example/demo/dto/cat/CatResponse.java
@@ -1,0 +1,22 @@
+package com.example.demo.dto.cat;
+
+import com.example.demo.domain.cat.Cat;
+import com.example.demo.dto.item.ItemResponse;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CatResponse {
+
+    private final String name;
+    private final List<ItemResponse> equipped;
+
+    public CatResponse(Cat cat) {
+        name = cat.getName();
+        equipped = cat.getEquippedItem().stream()
+            .map(ownedItem -> new ItemResponse(ownedItem.getItem()))
+            .toList();
+    }
+}

--- a/src/main/java/com/example/demo/dto/item/ItemResponse.java
+++ b/src/main/java/com/example/demo/dto/item/ItemResponse.java
@@ -1,0 +1,20 @@
+package com.example.demo.dto.item;
+
+import com.example.demo.domain.cat.Item;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ItemResponse {
+
+    private String imageUrl;
+    private Float offsetX;
+    private Float offsetY;
+
+    public ItemResponse(Item item) {
+        imageUrl = item.getImageUrl();
+        offsetX = item.getOffsetX();
+        offsetY = item.getOffsetY();
+    }
+}

--- a/src/main/java/com/example/demo/repository/CatRepository.java
+++ b/src/main/java/com/example/demo/repository/CatRepository.java
@@ -1,15 +1,18 @@
 package com.example.demo.repository;
 
 import com.example.demo.domain.cat.Cat;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
-
 public interface CatRepository extends JpaRepository<Cat, Long> {
 
     //Cat 가져올 시 반드시 아래 메서드를 사용해주세요
-    @Query("select distinct c from Cat c left join fetch c.ownedItems oi join fetch oi.item where c.id = :catId")
+    //@Query("select distinct c from Cat c left join fetch c.ownedItems oi join fetch oi.item where c.id = :catId")
+    @Query("select distinct c from Cat c " +
+        "left join fetch c.ownedItems oi " +
+        "left join fetch oi.item " +
+        "where c.id = :catId")
     Optional<Cat> findByIdJoinFetchOwnedItems(@Param("catId") Long id);
 }

--- a/src/main/java/com/example/demo/service/CatService.java
+++ b/src/main/java/com/example/demo/service/CatService.java
@@ -1,0 +1,43 @@
+package com.example.demo.service;
+
+import com.example.demo.domain.cat.Cat;
+import com.example.demo.domain.user.User;
+import com.example.demo.dto.cat.CatResponse;
+import com.example.demo.repository.CatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CatService {
+
+    private final CatRepository catRepository;
+
+    public CatResponse create(User user, String catName) {
+        if (catRepository.findByIdJoinFetchOwnedItems(user.getId()).isPresent()) {
+            throw new RuntimeException("이미 고양이가 생성되어있습니다.");
+        }
+        Cat created = new Cat(user, catName);
+        Cat saved = catRepository.save(created);
+        return new CatResponse(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public CatResponse get(User user) {
+        Cat found = findCat(user);
+        return new CatResponse(found);
+    }
+
+    public CatResponse rename(User user, String catName) {
+        Cat found = findCat(user);
+        found.rename(catName);
+        return new CatResponse(found);
+    }
+
+    private Cat findCat(User user) {
+        return catRepository.findByIdJoinFetchOwnedItems(user.getId())
+            .orElseThrow(() -> new RuntimeException("고양이를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 spring.application.name=nyangtodac
 spring.config.import=secrets.properties
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 고양이 생성, 조회, 수정(이름 변경) API를 추가하였습니다.
- CatRepository.findByIdJoinFetchOwnedItems()가 고양이를 조회해오지 못하는 문제를 수정했습니다.
- - 이번주 트러블 슈팅에서 다뤄보면 좋을거 같습니다!
- local 환경에서 h2-console에 접근을 허용하도록 SecurityFilterChain에 콘솔 경로를 추가하고  application 설정을 추가하였습니다.

### 추가 전달 사항
[ERD, API 명세](https://www.notion.so/teamsparta/ERD-API-2542dc3ef51480758e26c994587af23d)
- 고양이 API 명세 추가하였습니다. 경로는 최대한 간단하게 만들어 두었습니다. `/api/cats`
- CatResponse 구조: 고양이 이름과 외형(착용한 아이템) 정보만 최소한으로 담도록 설계하였습니다.

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [ ] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?

### 테스트 결과
**서비스 테스트 추후에 추가 하도록 하겠습니다!**
<img width="960" height="1020" alt="스크린샷 2025-09-10 031252" src="https://github.com/user-attachments/assets/22bbd43d-9d24-42f3-ab08-65da88d1b7a1" />
<img width="960" height="1020" alt="스크린샷 2025-09-10 031314" src="https://github.com/user-attachments/assets/79de63f7-cc42-4017-a691-1325dff10357" />
<img width="960" height="1020" alt="스크린샷 2025-09-10 031330" src="https://github.com/user-attachments/assets/99192a4b-3ba1-420a-8563-e0a1b5fd8e0d" />
