### PR TITLE
feat: Refresh Token을 이용한 Access Token 재발급 기능 구현

### DIFF
--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -35,8 +35,9 @@ public class SecurityConfig {
             .sessionManagement(
                 session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
+                // '/api/auth/reissue' 경로를 permitAll 목록에 추가
                 .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**",
-                    "/oauth2/**")
+                    "/oauth2/**", "/api/auth/reissue")
                 .permitAll()
                 .requestMatchers("/api/**").hasRole("USER")
                 .anyRequest().authenticated()

--- a/src/main/java/com/example/demo/controller/AuthController.java
+++ b/src/main/java/com/example/demo/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.example.demo.controller;
+
+import com.example.demo.dto.auth.TokenRequest;
+import com.example.demo.dto.auth.TokenResponse;
+import com.example.demo.service.auth.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenResponse> reissue(@RequestBody TokenRequest tokenRequest) {
+        TokenResponse tokenResponseDto = authService.reissue(tokenRequest);
+        return ResponseEntity.ok(tokenResponseDto);
+    }
+}

--- a/src/main/java/com/example/demo/dto/auth/TokenRequest.java
+++ b/src/main/java/com/example/demo/dto/auth/TokenRequest.java
@@ -1,0 +1,11 @@
+package com.example.demo.dto.auth;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenRequest {
+
+    private String refreshToken;
+}

--- a/src/main/java/com/example/demo/dto/auth/TokenResponse.java
+++ b/src/main/java/com/example/demo/dto/auth/TokenResponse.java
@@ -1,0 +1,12 @@
+package com.example.demo.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/example/demo/service/auth/AuthService.java
+++ b/src/main/java/com/example/demo/service/auth/AuthService.java
@@ -1,0 +1,43 @@
+package com.example.demo.service.auth;
+
+import com.example.demo.config.jwt.JwtTokenProvider;
+import com.example.demo.domain.user.User;
+import com.example.demo.dto.auth.TokenRequest;
+import com.example.demo.dto.auth.TokenResponse;
+import com.example.demo.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public TokenResponse reissue(TokenRequest tokenRequestDto) {
+
+        String refreshToken = tokenRequestDto.getRefreshToken();
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new RuntimeException("유효하지 않은 Refresh Token 입니다.");
+        }
+
+        Long userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        if (!user.getRefreshToken().equals(refreshToken)) {
+            throw new RuntimeException("DB의 토큰과 일치하지 않습니다.");
+        }
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(userId);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+        user.updateRefreshToken(newRefreshToken);
+
+        return new TokenResponse(newAccessToken, newRefreshToken);
+    }
+}


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
Access Token 만료 시 Refresh Token을 사용하여 새로운 Access Token을 재발급하는 기능 구현
기존 Access Token 만료 시 사용자가 다시 로그인해야 했지만, Refresh Token을 통해 사용자의 로그인 상태를 중단 없이 연장 가능

주요 구현 내용:
- **토큰 재발급 API 추가**: POST /api/auth/reissue 엔드포인트를 통해 토큰 재발급 요청 처리
- **AuthService 구현**: Refresh Token의 유효성 검증 및 DB에 저장된 토큰과 대조 후 새로운 Access Token 생성
- **Refresh Token Rotation**: 토큰 재발급 시마다 새로운 Refresh Token을 함께 발급하고 DB에 업데이트
- **SecurityConfig 수정**: /api/auth/reissue 경로는 Access Token 없이도 접근할 수 있도록 인증 예외 처리

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항
- 프론트엔드에서는  API 요청 시 401 Unauthorized 에러를 받으면, 보관하고 있던 refreshToken으로 /api/auth/reissue API를 호출 필요
- 응답으로 받은 새로운 accessToken과 refreshToken을 클라이언트 스토리지에 모두 업데이트 후, 실패했던 API 요청을 재시도하는 로직 필요

### 테스트 결과
Postman을 사용하여 아래 시나리오에 대한 테스트 완료
1. **API 접근**: 유효한 accessToken으로 보호된 API 호출 성공 확인
2. **토큰 재발급**: 만료된 accessToken을 가정하고, /api/auth/reissue API에 refreshToken을 전송하여 새로운 accessToken과 refreshToken이 정상적으로 발급 확인
3. **재발급된 토큰으로 API 접근**: 새로 발급받은 accessToken으로 다시 보호된 API 호출 성공 확인
4. **1회용 토큰 검증**: 사용했던 기존 refreshToken으로 재발급을 다시 시도했을 때, 발급 실패 확인