### PR TITLE
미션 데이터 수집 코드 갱신

### DIFF
--- a/src/main/java/com/example/demo/mission/regular/infrastructure/MissionBatchUpdater.java
+++ b/src/main/java/com/example/demo/mission/regular/infrastructure/MissionBatchUpdater.java
@@ -1,0 +1,52 @@
+package com.example.demo.mission.regular.infrastructure;
+
+import static com.example.demo.mission.regular.service.counter.MissionDelta.CounterType.COMPLETION;
+import static com.example.demo.mission.regular.service.counter.MissionDelta.CounterType.EXPOSURE;
+import static com.example.demo.mission.regular.service.counter.MissionDelta.CounterType.SELECTION;
+
+import com.example.demo.mission.regular.service.counter.MissionDelta;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Map.Entry;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class MissionBatchUpdater {
+
+    private final DataSource dataSource;
+
+    public void batchUpdateCounter(Map<Long, MissionDelta> deltas) {
+        String sql = "UPDATE missions "
+            + "SET exposure_count = exposure_count + ?, "
+            + "selection_count = selection_count + ?, "
+            + "completion_count = completion_count + ? "
+            + "where id = ?";
+
+        try (Connection conn = dataSource.getConnection();
+            PreparedStatement ps = conn.prepareStatement(sql)) {
+
+            for (Entry<Long, MissionDelta> entry : deltas.entrySet()) {
+                MissionDelta delta = entry.getValue();
+                ps.setInt(1, delta.getCount(EXPOSURE));
+                ps.setInt(2, delta.getCount(SELECTION));
+                ps.setInt(3, delta.getCount(COMPLETION));
+                ps.setLong(4, entry.getKey());
+                ps.addBatch();
+            }
+
+            ps.executeBatch();
+        } catch (SQLException e) {
+            log.error("Batch update mission counters failed. missionIds={} size={}",
+                deltas.keySet(), deltas.size(), e);
+        }
+
+    }
+
+}

--- a/src/main/java/com/example/demo/mission/regular/service/MissionTrackingService.java
+++ b/src/main/java/com/example/demo/mission/regular/service/MissionTrackingService.java
@@ -1,0 +1,29 @@
+package com.example.demo.mission.regular.service;
+
+import com.example.demo.mission.regular.service.counter.MissionCounterService;
+import com.example.demo.plan.controller.dto.PlanCreateRequest;
+import com.example.demo.plan.service.PlanInternalService;
+import com.example.demo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MissionTrackingService {
+
+    private final PlanInternalService planInternalService;
+    private final MissionCounterService missionCounterService;
+
+    public void addMissionToPlan(PlanCreateRequest request, User user) {
+        Long missionId = planInternalService.addMissionToPlan(request, user);
+        missionCounterService.addSelectionDelta(missionId);
+    }
+
+    public void updatePlanStatus(Long planId, boolean isDone, User user) {
+        Long missionId = planInternalService.updatePlanStatus(planId, isDone, user);
+        if (isDone) {
+            missionCounterService.addCompletionDelta(missionId);
+        }
+    }
+
+}

--- a/src/main/java/com/example/demo/mission/regular/service/counter/MissionCounterService.java
+++ b/src/main/java/com/example/demo/mission/regular/service/counter/MissionCounterService.java
@@ -1,0 +1,50 @@
+package com.example.demo.mission.regular.service.counter;
+
+import static com.example.demo.mission.regular.service.counter.MissionDelta.CounterType.COMPLETION;
+import static com.example.demo.mission.regular.service.counter.MissionDelta.CounterType.EXPOSURE;
+import static com.example.demo.mission.regular.service.counter.MissionDelta.CounterType.SELECTION;
+
+import com.example.demo.mission.regular.infrastructure.MissionBatchUpdater;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MissionCounterService {
+
+    @Getter
+    private final MissionDeltas missionDeltas = new MissionDeltas();
+    private final MissionBatchUpdater batchUpdater;
+
+    public void addExposureDelta(List<Long> missionIds) {
+        missionDeltas.increment(missionIds, EXPOSURE);
+    }
+
+    public void addSelectionDelta(Long missionId) {
+        missionDeltas.increment(missionId, SELECTION);
+    }
+
+    public void addCompletionDelta(Long missionId) {
+        missionDeltas.increment(missionId, COMPLETION);
+    }
+
+    @Transactional
+    @Scheduled(fixedRate = 5 * 60 * 1000) // 5분
+    public void flushDeltas() {
+        Map<Long, MissionDelta> deltas = missionDeltas.getDelta();
+        if (deltas.isEmpty()) {
+            return;
+        }
+
+        Map<Long, MissionDelta> snapshot = new HashMap<>(deltas);
+        deltas.clear();
+
+        batchUpdater.batchUpdateCounter(snapshot);
+    }
+}

--- a/src/main/java/com/example/demo/mission/regular/service/counter/MissionDelta.java
+++ b/src/main/java/com/example/demo/mission/regular/service/counter/MissionDelta.java
@@ -1,0 +1,29 @@
+package com.example.demo.mission.regular.service.counter;
+
+import java.util.EnumMap;
+
+public class MissionDelta {
+
+    private final EnumMap<CounterType, Integer> counts = new EnumMap<>(CounterType.class);
+
+    public MissionDelta() {
+        for (CounterType value : CounterType.values()) {
+            counts.put(value, 0);
+        }
+    }
+
+    public void increment(CounterType type) {
+        counts.merge(type, 1, Integer::sum);
+    }
+
+
+    public Integer getCount(CounterType type) {
+        return counts.get(type);
+    }
+
+    public enum CounterType {
+        EXPOSURE,
+        SELECTION,
+        COMPLETION
+    }
+}

--- a/src/main/java/com/example/demo/mission/regular/service/counter/MissionDeltas.java
+++ b/src/main/java/com/example/demo/mission/regular/service/counter/MissionDeltas.java
@@ -1,0 +1,28 @@
+package com.example.demo.mission.regular.service.counter;
+
+import com.example.demo.mission.regular.service.counter.MissionDelta.CounterType;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.Getter;
+
+@Getter
+public class MissionDeltas {
+
+    private final Map<Long, MissionDelta> delta = new ConcurrentHashMap<>();
+
+    public void increment(Long missionId, CounterType counterType) {
+        getMissionDelta(missionId).increment(counterType);
+    }
+
+    public void increment(List<Long> missionIds, CounterType counterType) {
+        for (Long missionId : missionIds) {
+            getMissionDelta(missionId).increment(counterType);
+        }
+    }
+
+    private MissionDelta getMissionDelta(Long missionId) {
+        return delta.computeIfAbsent(missionId, k -> new MissionDelta());
+    }
+
+}

--- a/src/main/java/com/example/demo/plan/domain/TodayPlans.java
+++ b/src/main/java/com/example/demo/plan/domain/TodayPlans.java
@@ -20,9 +20,10 @@ public class TodayPlans {
         plans.add(mission.toPlan(userId));
     }
 
-    public void updateDone(Long planId, boolean isDone) {
+    public Long updateDone(Long planId, boolean isDone) {
         Plan plan = getPlan(planId);
         plan.updateDone(isDone);
+        return plan.getMissionId();
     }
 
     public void deletePlan(Long planId) {

--- a/src/main/java/com/example/demo/plan/service/PlanInternalService.java
+++ b/src/main/java/com/example/demo/plan/service/PlanInternalService.java
@@ -1,0 +1,12 @@
+package com.example.demo.plan.service;
+
+import com.example.demo.plan.controller.dto.PlanCreateRequest;
+import com.example.demo.user.domain.User;
+
+public interface PlanInternalService {
+
+    Long addMissionToPlan(PlanCreateRequest request, User user);
+
+    Long updatePlanStatus(Long planId, boolean isDone, User user);
+
+}

--- a/src/main/java/com/example/demo/plan/service/PlanService.java
+++ b/src/main/java/com/example/demo/plan/service/PlanService.java
@@ -1,40 +1,9 @@
 package com.example.demo.plan.service;
 
-import com.example.demo.mission.Mission;
-import com.example.demo.mission.regular.service.MissionRepository;
-import com.example.demo.plan.controller.dto.PlanCreateRequest;
-import com.example.demo.plan.domain.TodayPlans;
 import com.example.demo.user.domain.User;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@Transactional
-@RequiredArgsConstructor
-public class PlanService {
+public interface PlanService {
 
-    private final PlanRepository planRepository;
-    private final MissionRepository missionRepository;
-
-    public void addMissionToPlan(PlanCreateRequest request, User user) {
-        Mission mission = missionRepository.findByIdAndType(request.getMissionId(),
-            request.getMissionType()).orElseThrow(() -> new RuntimeException("Mission Not Found"));
-        TodayPlans todayPlans = planRepository.findTodayPlans(user);
-        todayPlans.addMission(mission);
-        planRepository.saveAll(todayPlans.getPlans());
-    }
-
-    public void updatePlanStatus(Long planId, boolean isDone, User user) {
-        TodayPlans todayPlans = planRepository.findTodayPlans(user);
-        todayPlans.updateDone(planId, isDone);
-        planRepository.saveAll(todayPlans.getPlans());
-    }
-
-    public void deletePlan(Long planId, User user) {
-        TodayPlans todayPlans = planRepository.findTodayPlans(user);
-        todayPlans.deletePlan(planId);
-        planRepository.saveAll(todayPlans.getPlans());
-    }
+    void deletePlan(Long planId, User user);
 
 }

--- a/src/main/java/com/example/demo/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/example/demo/plan/service/PlanServiceImpl.java
@@ -1,0 +1,42 @@
+package com.example.demo.plan.service;
+
+import com.example.demo.mission.Mission;
+import com.example.demo.mission.regular.service.MissionRepository;
+import com.example.demo.plan.controller.dto.PlanCreateRequest;
+import com.example.demo.plan.domain.TodayPlans;
+import com.example.demo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PlanServiceImpl implements PlanService, PlanInternalService {
+
+    private final PlanRepository planRepository;
+    private final MissionRepository missionRepository;
+
+    public Long addMissionToPlan(PlanCreateRequest request, User user) {
+        Mission mission = missionRepository.findByIdAndType(request.getMissionId(),
+            request.getMissionType()).orElseThrow(() -> new RuntimeException("Mission Not Found"));
+        TodayPlans todayPlans = planRepository.findTodayPlans(user);
+        todayPlans.addMission(mission);
+        planRepository.saveAll(todayPlans.getPlans());
+        return mission.getId();
+    }
+
+    public Long updatePlanStatus(Long planId, boolean isDone, User user) {
+        TodayPlans todayPlans = planRepository.findTodayPlans(user);
+        Long missionId = todayPlans.updateDone(planId, isDone);
+        planRepository.saveAll(todayPlans.getPlans());
+        return missionId;
+    }
+
+    public void deletePlan(Long planId, User user) {
+        TodayPlans todayPlans = planRepository.findTodayPlans(user);
+        todayPlans.deletePlan(planId);
+        planRepository.saveAll(todayPlans.getPlans());
+    }
+
+}


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
1. 기존 미션 노출, 선택, 수행 횟수를 수집하는 코드를 가져왔습니다
2. 이벤트를 사용하는 방식에서 단순 메서드 호출 형태로 데이터 수집 방식을 변경하였습니다
- 미션 로직 수행 -> 수행이 완료 될 경우 데이터를 수집 하는 흐름으로 진행되어야 하므로 중간다리 역할을 하는 MissionTrackingService를 만들었습니다
- PlanInternalService를 만들고 해당 메서드들은 외부에서 사용되지 못하도록 MissionTrackingService 내부에서만 주입받았습니다
- 그 외 Plan의 서비스를 처리하는 코드들은 PlanService를 주입받아 사용하면 되는 형태로 만들었습니다

### 결론
PlanInternalService - MissionTrackingService 내부에서만 사용되는 플랜 서비스 역할을 하는 인터페이스
PlanService - 다른 컨트롤러에서 사용될 외부 서비스
PlanServiceImpl - PlanInternalService와 PlanService의 구현체

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?