### PR TITLE
정규미션, 커스텀 미션 리팩토링

### DIFF
--- a/src/main/java/com/example/demo/mission/custom/domain/CustomMission.java
+++ b/src/main/java/com/example/demo/mission/custom/domain/CustomMission.java
@@ -9,13 +9,11 @@ import lombok.Getter;
 @Getter
 public class CustomMission implements Mission {
 
-    private Long id;
+    private final Long id;
 
     private String content;
     private MissionCategoryEnum category;
     private final Long userId;
-
-    private CustomMissionStateEnum state;
 
     @Override
     public Plan toPlan(Long userId) {
@@ -27,17 +25,15 @@ public class CustomMission implements Mission {
         return MissionType.CUSTOM;
     }
 
-    public CustomMission(Long id, String content, MissionCategoryEnum category, Long userId,
-        CustomMissionStateEnum state) {
+    public CustomMission(Long id, String content, MissionCategoryEnum category, Long userId) {
         this.id = id;
         this.content = content;
         this.category = category;
         this.userId = userId;
-        this.state = state;
     }
 
     public CustomMission(String content, MissionCategoryEnum category, Long userId) {
-        this(null, content, category, userId, CustomMissionStateEnum.WAITING);
+        this(null, content, category, userId);
     }
 
     public void update(String content, MissionCategoryEnum category) {

--- a/src/main/java/com/example/demo/mission/custom/infrastructure/jpa/CustomMissionEntity.java
+++ b/src/main/java/com/example/demo/mission/custom/infrastructure/jpa/CustomMissionEntity.java
@@ -2,7 +2,6 @@ package com.example.demo.mission.custom.infrastructure.jpa;
 
 import com.example.demo.mission.MissionCategoryEnum;
 import com.example.demo.mission.custom.domain.CustomMission;
-import com.example.demo.mission.custom.domain.CustomMissionStateEnum;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -35,29 +34,24 @@ public class CustomMissionEntity {
     @Column(nullable = false)
     private MissionCategoryEnum category;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private CustomMissionStateEnum state;
-
     protected CustomMissionEntity() {
     }
 
     private CustomMissionEntity(Long id, Long userId, String content,
-        MissionCategoryEnum category, CustomMissionStateEnum state) {
+        MissionCategoryEnum category) {
         this.id = id;
         this.userId = userId;
         this.content = content;
         this.category = category;
-        this.state = state;
     }
 
     public static CustomMissionEntity fromModel(CustomMission customMission) {
         return new CustomMissionEntity(customMission.getId(), customMission.getUserId(),
-            customMission.getContent(), customMission.getCategory(), customMission.getState());
+            customMission.getContent(), customMission.getCategory());
     }
 
     public CustomMission toModel() {
-        return new CustomMission(id, content, category, userId, state);
+        return new CustomMission(id, content, category, userId);
     }
 
 }

--- a/src/main/java/com/example/demo/mission/custom/infrastructure/jpa/CustomMissionStateEnum.java
+++ b/src/main/java/com/example/demo/mission/custom/infrastructure/jpa/CustomMissionStateEnum.java
@@ -1,4 +1,4 @@
-package com.example.demo.mission.custom.domain;
+package com.example.demo.mission.custom.infrastructure.jpa;
 
 public enum CustomMissionStateEnum {
     WAITING,    // 필터 대기 상태

--- a/src/main/java/com/example/demo/mission/custom/infrastructure/jpa/CustomMissionStatus.java
+++ b/src/main/java/com/example/demo/mission/custom/infrastructure/jpa/CustomMissionStatus.java
@@ -3,11 +3,9 @@ package com.example.demo.mission.custom.infrastructure.jpa;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.OneToOne;
 import lombok.Getter;
 
 @Entity
@@ -19,16 +17,24 @@ public class CustomMissionStatus {
     @Id
     private Long customMissionId;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @MapsId
-    @JoinColumn(name = "custom_mission_id")
-    private CustomMissionEntity customMissionEntity;
-
     @Embedded
     private CustomMissionScore missionScore;
 
     @Column(nullable = false)
     private Integer level;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CustomMissionStateEnum state;
 
+    public CustomMissionStatus(Long customMissionId, CustomMissionScore missionScore, Integer level,
+        CustomMissionStateEnum state) {
+        this.customMissionId = customMissionId;
+        this.missionScore = missionScore;
+        this.level = level;
+        this.state = state;
+    }
+
+    protected CustomMissionStatus() {
+    }
 }

--- a/src/main/java/com/example/demo/mission/regular/domain/RegularMission.java
+++ b/src/main/java/com/example/demo/mission/regular/domain/RegularMission.java
@@ -4,30 +4,19 @@ import com.example.demo.mission.Mission;
 import com.example.demo.mission.MissionCategoryEnum;
 import com.example.demo.plan.domain.MissionType;
 import com.example.demo.plan.domain.Plan;
-import java.util.List;
 import lombok.Getter;
 
 @Getter
 public class RegularMission implements Mission {
 
-    private Long id;
-    private String content;
-    private MissionCategoryEnum category;
-    private Integer missionLevel;
-    private MissionScore missionScore;
-    private MissionCount missionCount;
-    private List<MissionTag> tags;
+    private final Long id;
+    private final String content;
+    private final MissionCategoryEnum category;
 
-    public RegularMission(Long id, String content, MissionCategoryEnum category,
-        Integer missionLevel, MissionScore missionScore, MissionCount missionCount,
-        List<MissionTag> tags) {
+    public RegularMission(Long id, String content, MissionCategoryEnum category) {
         this.id = id;
         this.content = content;
         this.category = category;
-        this.missionLevel = missionLevel;
-        this.missionScore = missionScore;
-        this.missionCount = missionCount;
-        this.tags = tags;
     }
 
     @Override

--- a/src/main/java/com/example/demo/mission/regular/infrastructure/jpa/RegularMissionEntity.java
+++ b/src/main/java/com/example/demo/mission/regular/infrastructure/jpa/RegularMissionEntity.java
@@ -60,14 +60,7 @@ public class RegularMissionEntity {
         this.missionTagEntities = missionTagEntities;
     }
 
-    public static RegularMissionEntity fromModel(RegularMission regularMission) {
-        return new RegularMissionEntity(regularMission.getId(), regularMission.getContent(), regularMission.getCategory(),
-            regularMission.getMissionLevel(), MissionScoreEmbeddable.fromModel(regularMission.getMissionScore()), MissionCountEmbeddable.fromModel(regularMission.getMissionCount()),
-            regularMission.getTags().stream().map(MissionTagEntity::fromModel).toList());
-    }
-
     public RegularMission toModel() {
-        return new RegularMission(id, content, category, missionLevel, missionScoreEmbeddable.toModel(), missionCountEmbeddable.toModel(),
-                missionTagEntities.stream().map(MissionTagEntity::toModel).toList());
+        return new RegularMission(id, content, category);
     }
 }

--- a/src/test/java/com/example/demo/domain/mission/CustomMissionTest.java
+++ b/src/test/java/com/example/demo/domain/mission/CustomMissionTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.example.demo.mission.MissionCategoryEnum;
 import com.example.demo.mission.custom.domain.CustomMission;
-import com.example.demo.mission.custom.domain.CustomMissionStateEnum;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -26,7 +25,6 @@ class CustomMissionTest {
         assertThat(mission.getContent()).isEqualTo(content);
         assertThat(mission.getCategory()).isEqualTo(category);
         assertThat(mission.getUserId()).isEqualTo(authorId);
-        assertThat(mission.getState()).isEqualTo(CustomMissionStateEnum.WAITING);
         assertThat(mission.getId()).isNull(); // ID는 저장 전이므로 null
     }
 

--- a/src/test/java/com/example/demo/domain/mission/RegularMissionTest.java
+++ b/src/test/java/com/example/demo/domain/mission/RegularMissionTest.java
@@ -35,29 +35,20 @@ class RegularMissionTest {
         RegularMission mission = new RegularMission(
             1L,
             "아침 7시에 일어나기",
-            MissionCategoryEnum.DAILY,
-            1,
-            missionScore,
-            missionCount,
-            tags
+            MissionCategoryEnum.DAILY
         );
 
         // then
         assertThat(mission.getId()).isEqualTo(1L);
         assertThat(mission.getContent()).isEqualTo("아침 7시에 일어나기");
         assertThat(mission.getCategory()).isEqualTo(MissionCategoryEnum.DAILY);
-        assertThat(mission.getMissionLevel()).isEqualTo(1);
-        assertThat(mission.getMissionScore()).isEqualTo(missionScore);
-        assertThat(mission.getMissionCount()).isEqualTo(missionCount);
-        assertThat(mission.getTags()).hasSize(2).containsAll(tags);
     }
 
     @Test
     @DisplayName("미션 타입을 'REGULAR'로 올바르게 반환한다.")
     void 미션_타입_올바르게_반환() {
         // given
-        RegularMission mission = new RegularMission(1L, "내용", MissionCategoryEnum.DAILY, 1,
-            missionScore, missionCount, tags);
+        RegularMission mission = new RegularMission(1L, "내용", MissionCategoryEnum.DAILY);
 
         // when
         MissionType missionType = mission.getMissionType();
@@ -74,11 +65,7 @@ class RegularMissionTest {
         RegularMission mission = new RegularMission(
             1L,
             "운동하기",
-            MissionCategoryEnum.REFRESH,
-            2,
-            missionScore,
-            missionCount,
-            tags
+            MissionCategoryEnum.REFRESH
         );
 
         // when


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
1. RegularMission의 필드를 수정하였습니다
  정규미션 도메인이 기존에 미션 난이도, 미션 점수, 미션 수집데이터, 태그 목록과 같이 도메인 비즈니스 로직에 필요없는 정보들을 가지고 있었는데 이 내용들을 모두 쳐내고 필요한 정보들만 남겨놓았습니다
2. 정규 미션은 조회용이므로 fromModel() 메서드가 필요없다고 판단하여 삭제하였습니다
3. CustomMission의 필드를 수정하였습니다
  기존에는 state라는 LLM을 통해 채점이 완료가 되었는지 확인하는 필드가 있었는데 이 또한 비즈니스 로직에는 필요가 없어 제외시키고 CustomMissionStatus 객체에 포함시켰습니다

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항
도메인 수정에 알맞게 테스트 코드도 수정 완료했습니다
