### PR TITLE
고양이 대화 기능 구현

### DIFF
--- a/src/main/java/com/example/demo/chat/controller/ChatController.java
+++ b/src/main/java/com/example/demo/chat/controller/ChatController.java
@@ -26,7 +26,7 @@ public class ChatController {
     @PostMapping
     public ResponseEntity<ChatResponse> postMessage(@RequestBody ChatRequest request,
         @CurrentUser User user) {
-        return ResponseEntity.ok(chatService.postMessage(request.getMessage(), user));
+        return ResponseEntity.ok(chatService.postMessage(request.getMessage(), user.getId()));
     }
 
     @GetMapping
@@ -35,6 +35,6 @@ public class ChatController {
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "10") int size
     ) {
-        return ResponseEntity.ok(chatService.getMessages(user, page, size));
+        return ResponseEntity.ok(chatService.getMessages(user.getId(), page, size));
     }
 }

--- a/src/main/java/com/example/demo/chat/controller/ChatController.java
+++ b/src/main/java/com/example/demo/chat/controller/ChatController.java
@@ -1,0 +1,40 @@
+package com.example.demo.chat.controller;
+
+import com.example.demo.chat.controller.dto.ChatRequest;
+import com.example.demo.chat.controller.dto.ChatResponse;
+import com.example.demo.chat.controller.dto.MessageResponse;
+import com.example.demo.chat.service.ChatService;
+import com.example.demo.common.auth.infrastructure.resolver.CurrentUser;
+import com.example.demo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @PostMapping
+    public ResponseEntity<ChatResponse> postMessage(@RequestBody ChatRequest request,
+        @CurrentUser User user) {
+        return ResponseEntity.ok(chatService.postMessage(request.getMessage(), user));
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<MessageResponse>> getMessages(
+        @CurrentUser User user,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(chatService.getMessages(user, page, size));
+    }
+}

--- a/src/main/java/com/example/demo/chat/controller/dto/ChatRequest.java
+++ b/src/main/java/com/example/demo/chat/controller/dto/ChatRequest.java
@@ -1,0 +1,12 @@
+package com.example.demo.chat.controller.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatRequest {
+
+    private String message;
+
+}

--- a/src/main/java/com/example/demo/chat/controller/dto/ChatResponse.java
+++ b/src/main/java/com/example/demo/chat/controller/dto/ChatResponse.java
@@ -1,0 +1,14 @@
+package com.example.demo.chat.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChatResponse {
+
+    private String message;
+
+    public ChatResponse(String message) {
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/example/demo/chat/controller/dto/MessageResponse.java
+++ b/src/main/java/com/example/demo/chat/controller/dto/MessageResponse.java
@@ -1,0 +1,21 @@
+package com.example.demo.chat.controller.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class MessageResponse {
+
+    private final Long chatId;
+    private final String message;
+    private final String reply;
+    private final LocalDateTime createdAt;
+
+    public MessageResponse(Long chatId, String message, String reply, LocalDateTime createdAt) {
+        this.chatId = chatId;
+        this.message = message;
+        this.reply = reply;
+        this.createdAt = createdAt;
+    }
+    
+}

--- a/src/main/java/com/example/demo/chat/infrastructure/MessageRepositoryImpl.java
+++ b/src/main/java/com/example/demo/chat/infrastructure/MessageRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.example.demo.chat.infrastructure;
+
+import com.example.demo.chat.infrastructure.jpa.Message;
+import com.example.demo.chat.infrastructure.jpa.MessageJpaRepository;
+import com.example.demo.chat.service.MessageRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MessageRepositoryImpl implements MessageRepository {
+
+    private final MessageJpaRepository messageJpaRepository;
+
+    @Override
+    public Message save(Message message) {
+        return messageJpaRepository.save(message);
+    }
+
+    @Override
+    public Page<Message> findByUserId(Long userId, Pageable pageable) {
+        return messageJpaRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+    }
+
+    @Override
+    public List<Message> findTopNByUserIdOrderByCreatedAtDesc(Long userId, int n) {
+        Pageable topN = PageRequest.of(0, n);
+        return messageJpaRepository.findByUserIdOrderByCreatedAtDesc(userId, topN).getContent();
+    }
+
+}

--- a/src/main/java/com/example/demo/chat/infrastructure/jpa/Message.java
+++ b/src/main/java/com/example/demo/chat/infrastructure/jpa/Message.java
@@ -9,9 +9,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.Getter;
 
 @Entity
 @Table(name = "message")
+@Getter
 public class Message {
 
     @Id
@@ -35,5 +37,12 @@ public class Message {
     private Integer dangerScore;
 
     protected Message() {
+    }
+
+    public Message(Long userId, Sender sender, String content, LocalDateTime createdAt) {
+        this.userId = userId;
+        this.sender = sender;
+        this.content = content;
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/example/demo/chat/infrastructure/jpa/MessageJpaRepository.java
+++ b/src/main/java/com/example/demo/chat/infrastructure/jpa/MessageJpaRepository.java
@@ -1,0 +1,13 @@
+package com.example.demo.chat.infrastructure.jpa;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageJpaRepository extends JpaRepository<Message, Long> {
+
+    Page<Message> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    List<Message> findTop10ByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/example/demo/chat/infrastructure/jpa/MessageJpaRepository.java
+++ b/src/main/java/com/example/demo/chat/infrastructure/jpa/MessageJpaRepository.java
@@ -1,6 +1,5 @@
 package com.example.demo.chat.infrastructure.jpa;
 
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +8,4 @@ public interface MessageJpaRepository extends JpaRepository<Message, Long> {
 
     Page<Message> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
-    List<Message> findTop10ByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/example/demo/chat/service/ChatService.java
+++ b/src/main/java/com/example/demo/chat/service/ChatService.java
@@ -1,0 +1,57 @@
+package com.example.demo.chat.service;
+
+import com.example.demo.chat.controller.dto.ChatResponse;
+import com.example.demo.chat.controller.dto.MessageResponse;
+import com.example.demo.chat.infrastructure.jpa.Message;
+import com.example.demo.chat.infrastructure.jpa.Sender;
+import com.example.demo.common.infrastructure.openai.OpenAiClient;
+import com.example.demo.common.infrastructure.openai.dto.OpenAiResponse;
+import com.example.demo.user.domain.User;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final OpenAiClient openAiClient;
+    private final MessageRepository messageRepository;
+
+    public ChatResponse postMessage(String messageContent, User user) {
+        List<Message> recentMessages = messageRepository.findTopNByUserIdOrderByCreatedAtDesc(
+            user.getId(), 10);
+        List<String> context = recentMessages.stream()
+            .map(Message::getContent)
+            .collect(Collectors.toList());
+        Collections.reverse(context);
+
+        OpenAiResponse openAiResponse = openAiClient.getChatResponse(messageContent, context);
+
+        Message userMessage = new Message(user.getId(), Sender.USER, messageContent,
+            LocalDateTime.now());
+        messageRepository.save(userMessage);
+
+        Message catMessage = new Message(user.getId(), Sender.CAT, openAiResponse.getMessage(),
+            LocalDateTime.now());
+        messageRepository.save(catMessage);
+
+        return new ChatResponse(openAiResponse.getMessage());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<MessageResponse> getMessages(User user, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return messageRepository.findByUserId(user.getId(), pageable)
+            .map(message -> new MessageResponse(message.getId(), message.getContent(), null,
+                message.getCreatedAt()));
+    }
+}

--- a/src/main/java/com/example/demo/chat/service/MessageRepository.java
+++ b/src/main/java/com/example/demo/chat/service/MessageRepository.java
@@ -1,0 +1,16 @@
+package com.example.demo.chat.service;
+
+import com.example.demo.chat.infrastructure.jpa.Message;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MessageRepository {
+
+    Message save(Message message);
+
+    Page<Message> findByUserId(Long userId, Pageable pageable);
+
+    List<Message> findTopNByUserIdOrderByCreatedAtDesc(Long userId, int n);
+
+}


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 사용자가 고양이와 자유롭게 대화할 수 있는 챗봇 기능 구현
- OpenAI API를 활용하여 고양이의 응답 생성
- 이전 대화 내용을 기억하고, 대화의 연속성을 유지하기 위해 최근 10개의 메시지를 컨텍스트로 활용
- 사용자와 고양이의 대화 내용 저장
- API 엔드포인트
    - POST /api/chat: 메시지 전송 및 AI 응답 반환
    - GET /api/chat: 이전 대화 내용 페이지네이션 조회

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항
- ChatService가 User 객체 대신 Long userId를 사용하도록 리팩토링

### 테스트 결과
- Postman을 사용하여 API가 명세에 따라 정상 동작 확인
    - POST /api/chat: 메시지를 보내면 AI가 생성한 응답이 정상적으로 반환
    - GET /api/chat: 이전 대화 기록이 페이지네이션과 함께 조회
- 테스트 입출력 결과 API 명세 문서에 기록 참고