### PR TITLE
feat: OAuth2 경로 설정

### DIFF
--- a/src/main/java/com/example/demo/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/common/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
                 session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**",
-                    "/oauth2/**", "/api/auth/reissue")
+                    "/oauth2/**", "/api/auth/reissue", "/api/login/oauth2/code/*",
+                    "/api/oauth2/authorization/*")
                 .permitAll()
                 .requestMatchers("/api/**").hasRole("USER")
                 .anyRequest().authenticated()
@@ -53,6 +54,12 @@ public class SecurityConfig {
             .formLogin(AbstractHttpConfigurer::disable)
             .logout(AbstractHttpConfigurer::disable)
             .oauth2Login(oauth2 -> oauth2
+                .authorizationEndpoint(endpoint -> endpoint
+                    .baseUri("/api/oauth2/authorization")
+                )
+                .redirectionEndpoint(endpoint -> endpoint
+                    .baseUri("/api/login/oauth2/code/*")
+                )
                 .userInfoEndpoint(userInfo -> userInfo
                     .userService(customOAuth2UserService)
                 )

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,13 +2,11 @@ spring.application.name=nyangtodac
 spring.config.import=secrets.properties
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
-
 spring.web.resources.add-mappings=false
-
 openai.clients.baseurl=https://api.openai.com
 openai.parameter.model=gpt-4o-mini
 openai.parameter.temperature=0.7
 openai.parameter.max-token=500
-
 spring.sql.init.mode=embedded
 spring.jpa.defer-datasource-initialization=true
+server.forward-headers-strategy=native

--- a/src/main/resources/secrets.properties.sample
+++ b/src/main/resources/secrets.properties.sample
@@ -1,6 +1,7 @@
 spring.security.oauth2.client.registration.google.client-id=[YOUR_CLIENT_ID]
 spring.security.oauth2.client.registration.google.client-secret=[YOUR_CLIENT_SECRET]
 spring.security.oauth2.client.registration.google.scope=profile,email
+spring.security.oauth2.client.registration.google.redirect-uri={baseUrl}/api/login/oauth2/code/google
 jwt.secret=[YOUR_JWT_SECRET_KEY]
 jwt.access-token-validity-in-seconds=3600
 jwt.refresh-token-validity-in-seconds=86400


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 구글 소셜 로그인이 정상적으로 동작하도록 인증 경로 및 관련 설정 수정
- `/api/**` 경로의 요청을 백엔드로 전달함에 따라 OAuth2 인증 경로가 `/api` 를 포함하도록 변경
- 로그인 시작 URL을 `/oauth2/authorization/**` 에서 `/api/oauth2/authorization/**` 으로 변경
- 로그인 리디렉션 URL을 `/login/oauth2/code/**` 에서 `/api/login/oauth2/code/**` 로 변경
- `server.forward-headers-strategy=native` 설정을 추가

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [x] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항
1. 구글 로그인을 시작하는 URL은 `.../api/oauth2/authorization/google`
2. Google Cloud Console에 '승인된 리디렉션 URL' 추가
3. secrets.properties 최신화 확인

### 테스트 결과
- `http://localhost:8080/api/oauth2/authorization/google` 로 로그인 시작 시 정상적으로 Google 인증 페이지로 이동 확인
- 인증 완료 후, 토큰 발급 성공 확인