### PR TITLE
채팅 기록 조회 API 응답 스펙 변경

### DIFF
--- a/src/main/java/com/example/demo/chat/controller/dto/MessageResponse.java
+++ b/src/main/java/com/example/demo/chat/controller/dto/MessageResponse.java
@@ -7,15 +7,18 @@ import lombok.Getter;
 public class MessageResponse {
 
     private final Long chatId;
+    private final String role;
     private final String message;
     private final String reply;
     private final LocalDateTime createdAt;
 
-    public MessageResponse(Long chatId, String message, String reply, LocalDateTime createdAt) {
+    public MessageResponse(Long chatId, String role, String message, String reply,
+        LocalDateTime createdAt) {
         this.chatId = chatId;
+        this.role = role;
         this.message = message;
         this.reply = reply;
         this.createdAt = createdAt;
     }
-    
+
 }

--- a/src/main/java/com/example/demo/chat/service/ChatService.java
+++ b/src/main/java/com/example/demo/chat/service/ChatService.java
@@ -6,10 +6,10 @@ import com.example.demo.chat.infrastructure.jpa.LongTermMemory;
 import com.example.demo.chat.infrastructure.jpa.LongTermMemoryJpaRepository;
 import com.example.demo.chat.infrastructure.jpa.Message;
 import com.example.demo.chat.infrastructure.jpa.Sender;
-import com.example.demo.openai.OpenAiClient;
-import com.example.demo.openai.dto.OpenAiResponse;
 import com.example.demo.emotion.domain.DangerState;
 import com.example.demo.emotion.service.EmotionService;
+import com.example.demo.openai.OpenAiClient;
+import com.example.demo.openai.dto.OpenAiResponse;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -34,7 +34,8 @@ public class ChatService {
     public ChatResponse postMessage(String messageContent, Long userId) {
         List<String> context = fetchContext(userId);
         LongTermMemory longTermMemory = fetchLongTermMemory(userId);
-        OpenAiResponse openAiResponse = openAiClient.getChatResponse(messageContent, context, longTermMemory.getMemory());
+        OpenAiResponse openAiResponse = openAiClient.getChatResponse(messageContent, context,
+            longTermMemory.getMemory());
 
         openAiResponse.getDangerScore().ifPresent(dangerScore -> {
             DangerState state = emotionService.applyAndGetDangerState(userId, dangerScore);
@@ -46,7 +47,8 @@ public class ChatService {
         Message userMessage = new Message(userId, Sender.USER, messageContent, dangerScore,
             LocalDateTime.now());
         messageRepository.save(userMessage);
-        Message catMessage = new Message(userId, Sender.CAT, openAiResponse.getMessage(), dangerScore,
+        Message catMessage = new Message(userId, Sender.CAT, openAiResponse.getMessage(),
+            dangerScore,
             LocalDateTime.now());
         messageRepository.save(catMessage);
 
@@ -57,12 +59,26 @@ public class ChatService {
     public Page<MessageResponse> getMessages(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         return messageRepository.findByUserId(userId, pageable)
-            .map(message -> new MessageResponse(message.getId(), message.getContent(), null,
-                message.getCreatedAt()));
+            .map(message -> {
+                String role = mapSenderToRole(message.getSender());
+                return new MessageResponse(message.getId(), role, message.getContent(), null,
+                    message.getCreatedAt());
+            });
+    }
+
+    private String mapSenderToRole(Sender sender) {
+        if (sender == Sender.USER) {
+            return "user";
+        }
+        if (sender == Sender.CAT) {
+            return "assistant";
+        }
+        return "unknown";
     }
 
     private List<String> fetchContext(Long userId) {
-        List<String> context = messageRepository.findTopNByUserIdOrderByCreatedAtDesc(userId, 10).stream()
+        List<String> context = messageRepository.findTopNByUserIdOrderByCreatedAtDesc(userId, 10)
+            .stream()
             .map(Message::getContent)
             .collect(Collectors.toList());
         Collections.reverse(context);


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 프론트엔드 UI 구분을 용이하게 하기 위해 이전 메시지 조회 API(GET /api/chat)의 응답 형식을 수정
1. MessageResponse DTO 수정
    - role 필드 추가
    - role 필드의 값은 'user', 'assistant' 문자열을 사용하도록 설정
2. ChatService.getMessages 로직 수정
    - Message 엔티티의 Sender Enum 값을 'user', 'assistant' 문자열로 매핑하여 MessageResponse DTO 생성하도록 수정

### PR 체크리스트
- [x] 정상적으로 실행이 되나요?
- [x] 빌드 성공했나요?
- [ ] 새로 등록한 환경변수가 있나요?
- [ ] 환경변수를 노션과 Cloud console에 등록했나요?
- [x] 컨벤션 규칙을 지켰나요?
- [x] merge branch 를 확인했나요?


### 추가 전달 사항
- API 명세서도 변경된 내용에 맞춰 수정 완료

### 테스트 결과
- Postman을 사용하여 GET /api/chat API 응답 형식이 변경된 사양에 맞게 반환되는 것 확인
    - role 필드가 'user' 또는 'assistant'로 표시 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages now include sender role information (user or assistant) to better distinguish message sources in chat conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->